### PR TITLE
Update to support laravel 5.4+

### DIFF
--- a/src/LocalizationServiceProvider.php
+++ b/src/LocalizationServiceProvider.php
@@ -30,14 +30,12 @@ class LocalizationServiceProvider extends ServiceProvider
             $packageConfigFile, 'localization'
         );
 
-        $this->app['localization.localize'] = $this->app->share(
-            function () {
+        $this->app->singleton('localization.localize', function () {
                 return new Localize();
             }
         );
 
-        $this->app['localization.router'] = $this->app->share(
-            function () {
+        $this->app->singleton('localization.router', function () {
                 return new Router();
             }
         );


### PR DESCRIPTION
Change `share` method to `singleton` because `share` is deleted in Laravel 5.4+ versions.

In [Laravel 5.3 to 5.4 upgrade guide](https://laravel.com/docs/5.4/upgrade#upgrade-5.4.0) we can find this text:

### `share` Method Removed

The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the singleton method instead:

```php
$container->singleton('foo', function () {
    return 'foo';
});
```